### PR TITLE
Rename `onInit`

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ async function log(message) {
 }
 
 module.exports = {
-    onInit: async ({constants, inputs, utils}) => {
+    onPreBuild: async ({constants, inputs, utils}) => {
         const parsedBuildMinutesRequired = parseInt(inputs.buildMinutesRequired);
         const reprBuildMinutesRequired = JSON.stringify(inputs.buildMinutesRequired);
         if (Number.isNaN(parsedBuildMinutesRequired)) {


### PR DESCRIPTION
At the moment, `onInit` is an alias of `onPreBuild`. We are working on bringing a real `onInit` which would be triggered much earlier in the build. In the meantime, we are currently removing `onInit` to prevent confusion. This PR implements this renaming. 